### PR TITLE
Publish closest traffic light info (without CNN output)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ attrdict==2.0.0
 eventlet==0.19.0
 python-socketio==1.6.1
 numpy==1.13.1
-Pillow==2.2.1
+Pillow==4.3.0
 scipy==0.19.1
 keras==2.0.8
 tensorflow==1.3.0

--- a/ros/src/tl_detector/light_classification/tl_classifier.py
+++ b/ros/src/tl_detector/light_classification/tl_classifier.py
@@ -16,4 +16,7 @@ class TLClassifier(object):
 
         """
         #TODO implement light color prediction
-        return TrafficLight.UNKNOWN
+        #return TrafficLight.UNKNOWN
+
+        # currently always set to RED for testing purpose
+        return TrafficLight.RED

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -5,6 +5,8 @@ from geometry_msgs.msg import PoseStamped, Pose
 from styx_msgs.msg import TrafficLightArray, TrafficLight
 from styx_msgs.msg import Lane
 from sensor_msgs.msg import Image
+from scipy.spatial import KDTree
+import numpy as np
 from cv_bridge import CvBridge
 from light_classification.tl_classifier import TLClassifier
 import tf
@@ -19,6 +21,8 @@ class TLDetector(object):
 
         self.pose = None
         self.waypoints = None
+        self.waypoints_2d = None
+        self.waypoint_tree = None
         self.camera_image = None
         self.lights = []
 
@@ -56,6 +60,12 @@ class TLDetector(object):
 
     def waypoints_cb(self, waypoints):
         self.waypoints = waypoints
+        if not self.waypoints_2d:
+            self.waypoints_2d = [[waypoint.pose.pose.position.x,
+                                  waypoint.pose.pose.position.y
+                                 ]
+                                for waypoint in waypoints.waypoints]
+            self.waypoint_tree = KDTree(self.waypoints_2d)
 
     def traffic_cb(self, msg):
         self.lights = msg.lights
@@ -90,18 +100,34 @@ class TLDetector(object):
             self.upcoming_red_light_pub.publish(Int32(self.last_wp))
         self.state_count += 1
 
-    def get_closest_waypoint(self, pose):
+    def get_closest_waypoint(self, x, y):
         """Identifies the closest path waypoint to the given position
             https://en.wikipedia.org/wiki/Closest_pair_of_points_problem
         Args:
-            pose (Pose): position to match a waypoint to
+            x: x coordinate
+            y: y coordinate
 
         Returns:
             int: index of the closest waypoint in self.waypoints
 
         """
-        #TODO implement
-        return 0
+        closest_idx = self.waypoint_tree.query([x, y], 1)[1]
+
+        # Check if closest is ahead or behind the vehicle
+        closest_coord = self.waypoints_2d[closest_idx]
+        prev_coord = self.waypoints_2d[closest_idx - 1]
+
+        # Equation for hyperplane through closest_coords
+        cl_vect = np.array(closest_coord)
+        prev_vect = np.array(prev_coord)
+        pos_vect = np.array([x, y])
+
+        val = np.dot(cl_vect-prev_vect, pos_vect-cl_vect)
+
+        if val > 0:
+            closest_idx = (closest_idx + 1) % len(self.waypoints_2d)
+
+        return closest_idx
 
     def get_light_state(self, light):
         """Determines the current color of the traffic light
@@ -131,19 +157,33 @@ class TLDetector(object):
             int: ID of traffic light color (specified in styx_msgs/TrafficLight)
 
         """
-        light = None
+        closest_light = None
+        line_wp_idx = None
 
-        # List of positions that correspond to the line to stop in front of for a given intersection
+        # load the list of stop line positions
         stop_line_positions = self.config['stop_line_positions']
-        if(self.pose):
-            car_position = self.get_closest_waypoint(self.pose.pose)
+        if (self.pose):
+            car_wp_idx = self.get_closest_waypoint(self.pose.pose.position.x,
+                                                   self.pose.pose.position.y)
+            # find closest traffic light
+            diff = len(self.waypoints.waypoints)
+            for i, light in enumerate(self.lights):
+                # get stop line waypoint index
+                line = stop_line_positions[i]
+                temp_wp_idx = self.get_closest_waypoint(line[0], line[1])
+                # find closest stop line waypoint index
+                d = temp_wp_idx - car_wp_idx
+                if d >= 0 and d < diff:
+                    diff = d
+                    closest_light = light
+                    line_wp_idx = temp_wp_idx
 
-        #TODO find the closest visible traffic light (if one exists)
+        rospy.loginfo("current way point is: %d", car_wp_idx)
+        rospy.loginfo("closest lightis : %d", line_wp_idx)
+        if closest_light:
+            state = self.get_light_state(closest_light)
+            return line_wp_idx, state
 
-        if light:
-            state = self.get_light_state(light)
-            return light_wp, state
-        self.waypoints = None
         return -1, TrafficLight.UNKNOWN
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR computes and publishes the closest traffic light and stop line info. It is part of the tl_detector module except that the CNN tl_classifier is missing. I assume the classifier output is always RED for the moment. We can replace it with the CNN output later. I still need to do more improvements. But it would be nice to have the basic parts into master.

If u want to see debug messages, u can run:
`roslaunch --screen launch/styx.launch`

The Pillow package version change is to fix a bug for docker container based on the forum. If u do not use docker, it might not affect u.
https://discussions.udacity.com/t/issue-simulator-talking-to-docker/411204