### PR TITLE
Fix waypoint delay

### DIFF
--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -109,12 +109,13 @@ class TLDetector(object):
             self.upcoming_red_light_pub.publish(Int32(self.last_wp))
         self.state_count += 1
 
-    def get_closest_waypoint(self, x, y):
+    def get_closest_waypoint(self, x, y, is_front):
         """Identifies the closest path waypoint to the given position
             https://en.wikipedia.org/wiki/Closest_pair_of_points_problem
         Args:
             x: x coordinate
             y: y coordinate
+            is_front: should the closest waypoint be in front of the query point or not
 
         Returns:
             int: index of the closest waypoint in self.waypoints
@@ -122,7 +123,6 @@ class TLDetector(object):
         """
         closest_idx = self.waypoint_tree.query([x, y], 1)[1]
 
-        """
         # Check if closest is ahead or behind the vehicle
         closest_coord = self.waypoints_2d[closest_idx]
         prev_coord = self.waypoints_2d[closest_idx - 1]
@@ -134,9 +134,11 @@ class TLDetector(object):
 
         val = np.dot(cl_vect-prev_vect, pos_vect-cl_vect)
 
-        if val > 0:
+        if val > 0 and is_front:
             closest_idx = (closest_idx + 1) % len(self.waypoints_2d)
-        """
+        if val < 0 and not is_front:
+            closest_idx = (closest_idx - 1) % len(self.waypoints_2d)
+
         return closest_idx
 
     def get_light_state(self, light):
@@ -176,13 +178,14 @@ class TLDetector(object):
         stop_line_positions = self.config['stop_line_positions']
         if (self.pose):
             car_wp_idx = self.get_closest_waypoint(self.pose.pose.position.x,
-                                                   self.pose.pose.position.y)
+                                                   self.pose.pose.position.y,
+                                                   True)
             # find closest traffic light
             diff = len(self.waypoints.waypoints)
             for i, light in enumerate(self.lights):
                 # get stop line waypoint index
                 line = stop_line_positions[i]
-                temp_wp_idx = self.get_closest_waypoint(line[0], line[1])
+                temp_wp_idx = self.get_closest_waypoint(line[0], line[1], False)
                 # find closest stop line waypoint index
                 d = temp_wp_idx - car_wp_idx
                 if d >= 0 and d < diff:

--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -38,6 +38,7 @@ class Controller(object):
             self.throttle_controller.reset()
             return 0., 0., 0.
 
+        rospy.loginfo("current v is : %f", current_vel)
         current_vel = self.vel_lpf.filt(current_vel)
 
         # rospy.logwarn("Angular vel: {0}".format(angular_vel))

--- a/ros/src/waypoint_follower/src/pure_pursuit.cpp
+++ b/ros/src/waypoint_follower/src/pure_pursuit.cpp
@@ -56,11 +56,11 @@ int main(int argc, char **argv)
   ROS_INFO("set subscriber...");
   // subscribe topic
   ros::Subscriber waypoint_subscriber =
-      nh.subscribe("final_waypoints", 10, &waypoint_follower::PurePursuit::callbackFromWayPoints, &pp);
+      nh.subscribe("final_waypoints", 1, &waypoint_follower::PurePursuit::callbackFromWayPoints, &pp);
   ros::Subscriber ndt_subscriber =
-      nh.subscribe("current_pose", 10, &waypoint_follower::PurePursuit::callbackFromCurrentPose, &pp);
+      nh.subscribe("current_pose", 1, &waypoint_follower::PurePursuit::callbackFromCurrentPose, &pp);
   ros::Subscriber est_twist_subscriber =
-      nh.subscribe("current_velocity", 10, &waypoint_follower::PurePursuit::callbackFromCurrentVelocity, &pp);
+      nh.subscribe("current_velocity", 1, &waypoint_follower::PurePursuit::callbackFromCurrentVelocity, &pp);
 
   ROS_INFO("pure pursuit start");
   ros::Rate loop_rate(LOOP_RATE);


### PR DESCRIPTION
The main cause of delay I found was that the waypoint subscribers has a queue size of 10 in `pure_pursuit.cpp`. We always want the latest data in this case, instead of buffered info. The rospy subscriber has a default queue size of 1, so we do not have problem there. I did some other improvements to hopefully make the system work better.

It might also help if we populate the time stamp in this messages. It will be easier to handle delays in this way. I have some debug messages in there and will clean them up later.