### PR TITLE
Changed inference frequency in tl_detector.py to 10Hz

### DIFF
--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -95,7 +95,7 @@ class TLDetector(object):
         perform task at 30Hz
         publish upcoming lights only when pose, waypoints and camera images are available 
         """
-        r = rospy.Rate(20)
+        r = rospy.Rate(10)
         
         while not rospy.is_shutdown():
 


### PR DESCRIPTION
	We have calculated that it takes about 0.08s to do one inference,
	which corresponds to about 12.5Hz. This means it should be a good
	idea to decrease the frequency to about 10Hz
Changes to be committed:
	modified:   ros/src/tl_detector/tl_detector.py